### PR TITLE
"!pblimiter status" output modifications

### DIFF
--- a/HaE PBLimiter/Commands/PlayerCommands.cs
+++ b/HaE PBLimiter/Commands/PlayerCommands.cs
@@ -25,7 +25,7 @@ namespace HaE_PBLimiter.Commands
 
             if (ProfilerConfig.perPlayer && PBPlayerTracker.players.ContainsKey(player.IdentityId))
             {
-                sb.AppendLine($"Player \"{player.DisplayName}\" Ms: {PBPlayerTracker.players[player.IdentityId]?.ms}/{ProfilerConfig.maxTickTime}");
+                sb.AppendLine($"Player \"{player.DisplayName}\" Ms: {Math.Round(PBPlayerTracker.players[player.IdentityId].ms, 3)}/{ProfilerConfig.maxTickTime}");
             }
 
             foreach (var pb in PBData.pbPair.Values.Where(v => v.PB.OwnerId == player.IdentityId).OrderByDescending(v => v.AverageMS))

--- a/HaE PBLimiter/Commands/PlayerCommands.cs
+++ b/HaE PBLimiter/Commands/PlayerCommands.cs
@@ -5,6 +5,8 @@ using System.Text;
 using System.Threading.Tasks;
 using Torch.Commands;
 using Torch.Commands.Permissions;
+using Torch.Mod;
+using Torch.Mod.Messages;
 using VRage.Game.ModAPI;
 
 namespace HaE_PBLimiter.Commands
@@ -25,7 +27,7 @@ namespace HaE_PBLimiter.Commands
 
             if (ProfilerConfig.perPlayer && PBPlayerTracker.players.ContainsKey(player.IdentityId))
             {
-                sb.AppendLine($"Player \"{player.DisplayName}\" Ms: {Math.Round(PBPlayerTracker.players[player.IdentityId].ms, 3)}/{ProfilerConfig.maxTickTime}");
+                sb.AppendLine($"Player \"{player.DisplayName}\" Ms: {PBPlayerTracker.players[player.IdentityId].ms:F3}/{ProfilerConfig.maxTickTime}\n");
             }
 
             foreach (var pb in PBData.pbPair.Values.Where(v => v.PB.OwnerId == player.IdentityId).OrderByDescending(v => v.AverageMS))
@@ -33,7 +35,7 @@ namespace HaE_PBLimiter.Commands
                 sb.AppendLine($"PB: \"{pb.PBID}\" Ms: {pb.AverageMS:F3}");
             }
 
-            Context.Respond(sb.ToString());
+            ModCommunication.SendMessageTo(new DialogMessage($"PBLimiter Status", null, sb.ToString()), Context.Player.SteamUserId);
         }
     }
 }

--- a/HaE PBLimiter/Commands/PlayerCommands.cs
+++ b/HaE PBLimiter/Commands/PlayerCommands.cs
@@ -23,10 +23,14 @@ namespace HaE_PBLimiter.Commands
 
             var sb = new StringBuilder();
 
-            foreach (var pb in PBData.pbPair.Values)
+            if (ProfilerConfig.perPlayer && PBPlayerTracker.players.ContainsKey(player.IdentityId))
             {
-                if (pb.PB.OwnerId == player.IdentityId)
-                    sb.AppendLine($"PB: \"{pb.PBID}\" Ms: {pb.AverageMS:F3}");
+                sb.AppendLine($"Player \"{player.DisplayName}\" Ms: {PBPlayerTracker.players[player.IdentityId]?.ms}/{ProfilerConfig.maxTickTime}");
+            }
+
+            foreach (var pb in PBData.pbPair.Values.Where(v => v.PB.OwnerId == player.IdentityId).OrderByDescending(v => v.AverageMS))
+            {
+                sb.AppendLine($"PB: \"{pb.PBID}\" Ms: {pb.AverageMS:F3}");
             }
 
             Context.Respond(sb.ToString());

--- a/HaE PBLimiter/HaE PBLimiter.csproj
+++ b/HaE PBLimiter/HaE PBLimiter.csproj
@@ -49,19 +49,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ControlzEx">
-      <HintPath>..\..\..\..\servers\Torch Versions\TorchBin\ControlzEx.dll</HintPath>
+      <HintPath>D:\torch-server\ControlzEx.dll</HintPath>
     </Reference>
     <Reference Include="HavokWrapper">
       <HintPath>D:\Programs\steam\steamapps\common\SpaceEngineers\Bin64\HavokWrapper.dll</HintPath>
     </Reference>
     <Reference Include="MahApps.Metro">
-      <HintPath>..\..\..\..\servers\Torch Versions\TorchBin\MahApps.Metro.dll</HintPath>
+      <HintPath>D:\torch-server\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>Y:\Space Engineers\Torch\Newtonsoft.Json.dll</HintPath>
+      <HintPath>D:\torch-server\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog">
-      <HintPath>..\..\..\..\servers\Torch Versions\TorchBin\NLog.dll</HintPath>
+      <HintPath>D:\torch-server\NLog.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -98,13 +98,13 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Torch">
-      <HintPath>..\..\..\..\servers\Torch Versions\TorchBin\Torch.dll</HintPath>
+      <HintPath>D:\torch-server\Torch.dll</HintPath>
     </Reference>
     <Reference Include="Torch.API">
-      <HintPath>..\..\..\..\servers\Torch Versions\TorchBin\Torch.API.dll</HintPath>
+      <HintPath>D:\torch-server\Torch.API.dll</HintPath>
     </Reference>
     <Reference Include="Torch.Server">
-      <HintPath>..\..\..\..\servers\Torch Versions\TorchBin\Torch.Server.exe</HintPath>
+      <HintPath>D:\torch-server\Torch.Server.exe</HintPath>
     </Reference>
     <Reference Include="VRage">
       <HintPath>D:\Programs\steam\steamapps\common\SpaceEngineers\Bin64\VRage.dll</HintPath>


### PR DESCRIPTION
I've made several modifications to PBLimiter status output, so it will display it's status in a dialog window instead of chat. Sort PBs according to their average time and display total time in per-player mode. I hope you'll like that.

![pb output](https://user-images.githubusercontent.com/2816075/78560531-e7b56c00-781e-11ea-8844-91c5b706977c.png)